### PR TITLE
Meeting's Title isn't changed #47

### DIFF
--- a/test/src/main/po/org/xwiki/contrib/meeting/test/ui/po/MeetingEntryInlinePage.java
+++ b/test/src/main/po/org/xwiki/contrib/meeting/test/ui/po/MeetingEntryInlinePage.java
@@ -45,12 +45,6 @@ public class MeetingEntryInlinePage extends InlinePage
     public static final String SUGGEST_ITEM_CLASS_NAME = "suggestItem";
 
     /**
-     * The meeting entry title input field.
-     */
-    @FindBy(id = "Meeting.Code.MeetingClass_0_meetingTitle")
-    private WebElement titleInput;
-
-    /**
      * The meeting entry start date input field.
      */
     @FindBy(id = "Meeting.Code.MeetingClass_0_startDate")
@@ -97,25 +91,6 @@ public class MeetingEntryInlinePage extends InlinePage
      */
     @FindBy(id = "Meeting.Code.MeetingClass_0_participants")
     private WebElement participantsInput;
-
-    /**
-     * @return the value of the title input field
-     */
-    public String getTitle()
-    {
-        return titleInput.getAttribute(VALUE_ATTRIBUTE_NAME);
-    }
-
-    /**
-     * Sets the value of the title input field.
-     *
-     * @param title the new meeting entry title
-     */
-    public void setTitle(String title)
-    {
-        titleInput.clear();
-        titleInput.sendKeys(title);
-    }
 
     /**
      * @return the value of the start date input field

--- a/test/src/test/it/org/xwiki/contrib/meeting/test/ui/MeetingTest.java
+++ b/test/src/test/it/org/xwiki/contrib/meeting/test/ui/MeetingTest.java
@@ -93,7 +93,6 @@ public class MeetingTest extends AbstractTest
         createPage.clickCreate();
 
         MeetingEntryInlinePage meetingEntryInlinePage = new MeetingEntryInlinePage();
-        meetingEntryInlinePage.setTitle("Meeting 01");
         meetingEntryInlinePage.setStartDate(getDateTomorrow());
         meetingEntryInlinePage.setEndDate(getEndDate());
         meetingEntryInlinePage.setPlace("Paris");

--- a/ui/src/main/resources/Meeting/Code/Macros.xml
+++ b/ui/src/main/resources/Meeting/Code/Macros.xml
@@ -156,38 +156,5 @@
     END:VCALENDAR
   ")
 #end
-
-#macro (testMigrationNeeded)
-  #set($query = "from doc.object(Meeting.Code.MeetingClass) as meeting")
-  #set($meetings = $services.query.xwql($query).execute())
-  #set($migrationNeeded = false)
-  #set($migration191 = false)
-  #set($migration195 = false)
-  #foreach($meet in $meetings)
-    #set($meetDoc = $xwiki.getDocument($meet))
-    #set($meetObj = $meetDoc.getObject('Meeting.Code.MeetingClass'))
-    #set($durationString = $meetObj.getValue('durationString'))
-    #set($meetingTitle = $meetObj.getValue('meetingTitle'))
-    #if ($durationString)
-      #set($migrationNeeded = true)
-      #set($migration191 = true)
-    #end
-    #if ($!meetingTitle)
-      #set($migrationNeeded = true)
-      #set($migration195 = true)
-    #end
-  #end
-  #if($migrationNeeded)
-    {{error}}
-      $services.localization.render('meeting.home.migrations')
-      #if($migration191)
-        [[Meeting.Code.Migrations.1\.9\.1]]
-      #end
-      #if($migration195)
-        [[Meeting.Code.Migrations.1\.9\.5]]
-      #end
-    {{/error}}
-  #end
-#end
 {{/velocity}}</content>
 </xwikidoc>

--- a/ui/src/main/resources/Meeting/Code/Macros.xml
+++ b/ui/src/main/resources/Meeting/Code/Macros.xml
@@ -161,18 +161,31 @@
   #set($query = "from doc.object(Meeting.Code.MeetingClass) as meeting")
   #set($meetings = $services.query.xwql($query).execute())
   #set($migrationNeeded = false)
+  #set($migration191 = false)
+  #set($migration195 = false)
   #foreach($meet in $meetings)
     #set($meetDoc = $xwiki.getDocument($meet))
     #set($meetObj = $meetDoc.getObject('Meeting.Code.MeetingClass'))
-    #set($durationString = $meetObj.getProperty('durationString').value)
+    #set($durationString = $meetObj.getValue('durationString'))
+    #set($meetingTitle = $meetObj.getValue('meetingTitle'))
     #if ($durationString)
       #set($migrationNeeded = true)
-      #break
+      #set($migration191 = true)
+    #end
+    #if ($!meetingTitle)
+      #set($migrationNeeded = true)
+      #set($migration195 = true)
     #end
   #end
   #if($migrationNeeded)
     {{error}}
-      $services.localization.render('meeting.home.migrations') [[Meeting.Code.Migrations.2\.0]]
+      $services.localization.render('meeting.home.migrations')
+      #if($migration191)
+        [[Meeting.Code.Migrations.1\.9\.1]]
+      #end
+      #if($migration195)
+        [[Meeting.Code.Migrations.1\.9\.5]]
+      #end
     {{/error}}
   #end
 #end

--- a/ui/src/main/resources/Meeting/Code/MeetingClass.xml
+++ b/ui/src/main/resources/Meeting/Code/MeetingClass.xml
@@ -191,19 +191,6 @@
       <validationRegExp/>
       <classType>com.xpn.xwiki.objects.classes.UsersClass</classType>
     </leader>
-    <meetingTitle>
-      <customDisplay/>
-      <disabled>0</disabled>
-      <name>meetingTitle</name>
-      <number>1</number>
-      <picker>0</picker>
-      <prettyName>Title</prettyName>
-      <size>30</size>
-      <unmodifiable>0</unmodifiable>
-      <validationMessage/>
-      <validationRegExp/>
-      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-    </meetingTitle>
     <notes>
       <customDisplay/>
       <disabled>0</disabled>

--- a/ui/src/main/resources/Meeting/Code/MeetingSheet.xml
+++ b/ui/src/main/resources/Meeting/Code/MeetingSheet.xml
@@ -31,10 +31,10 @@
   <parent>Meeting.MeetingClass</parent>
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <date>1511513778000</date>
-  <contentUpdateDate>1511513778000</contentUpdateDate>
+  <date>1556017935000</date>
+  <contentUpdateDate>1556017935000</contentUpdateDate>
   <version>1.1</version>
-  <title>#if("$!doc.getObject('Meeting.Code.MeetingClass').getValue('meetingTitle')" != '')$!doc.getObject('Meeting.Code.MeetingClass').getValue('meetingTitle') #elseif($doc.name=='MeetingSheet')Meeting Sheet #else${doc.title} #end</title>
+  <title/>
   <comment/>
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>
@@ -85,25 +85,6 @@
 ## We don't have access to the form element to set the CSS class for the vertical form layout standard.
 (% class="xform" %)
 (((
-
-  (% class="row" %)
-  (((
-    (% class="col-md-12 col-sm-12 col-xs-12" %)
-    (((
-    #if ($xcontext.action == 'edit')
-      ## Add a title of event in edit mode.
-      #set ($meetingTitleId = 'Meeting.Code.MeetingClass_0_meetingTitle')
-      ; &lt;label for="$meetingTitleId"&gt;
-          $!services.icon.render('font') $services.localization.render('contrib.meeting.field.meetingTitle')
-        &lt;/label&gt;
-      #if ("$!obj.getValue('meetingTitle')" == '')
-        #set ($discard = $obj.set('meetingTitle', $doc.title))
-      #end
-      : $doc.display('meetingTitle')
-    #end
-    )))
-  )))
-
   (% class="row" %)
   (((
     (% class="col-xs-12 col-sm-4" %)

--- a/ui/src/main/resources/Meeting/Code/MeetingSheet.xml
+++ b/ui/src/main/resources/Meeting/Code/MeetingSheet.xml
@@ -34,7 +34,7 @@
   <date>1511513778000</date>
   <contentUpdateDate>1511513778000</contentUpdateDate>
   <version>1.1</version>
-  <title/>
+  <title>#if("$!doc.getObject('Meeting.Code.MeetingClass').getValue('meetingTitle')" != '')$!doc.getObject('Meeting.Code.MeetingClass').getValue('meetingTitle') #elseif($doc.name=='MeetingSheet')Meeting Sheet #else${doc.title} #end</title>
   <comment/>
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>
@@ -91,16 +91,15 @@
     (% class="col-md-12 col-sm-12 col-xs-12" %)
     (((
     #if ($xcontext.action == 'edit')
-      ## Add a title of event in edit modetime
-      #set ($title = $request.title)
-      #if ("$!title" == '')
-        #set ($title = $doc.getValue('meetingTitle'))
-      #end
+      ## Add a title of event in edit mode.
       #set ($meetingTitleId = 'Meeting.Code.MeetingClass_0_meetingTitle')
       ; &lt;label for="$meetingTitleId"&gt;
           $!services.icon.render('font') $services.localization.render('contrib.meeting.field.meetingTitle')
         &lt;/label&gt;
-      : &lt;input id="$meetingTitleId" name="$meetingTitleId" size="30" type="text" value="$escapetool.xml($title)"&gt;
+      #if ("$!obj.getValue('meetingTitle')" == '')
+        #set ($discard = $obj.set('meetingTitle', $doc.title))
+      #end
+      : $doc.display('meetingTitle')
     #end
     )))
   )))

--- a/ui/src/main/resources/Meeting/Code/MeetingSheet.xml
+++ b/ui/src/main/resources/Meeting/Code/MeetingSheet.xml
@@ -31,8 +31,8 @@
   <parent>Meeting.MeetingClass</parent>
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <date>1556017935000</date>
-  <contentUpdateDate>1556017935000</contentUpdateDate>
+  <date>1511513778000</date>
+  <contentUpdateDate>1511513778000</contentUpdateDate>
   <version>1.1</version>
   <title/>
   <comment/>

--- a/ui/src/main/resources/Meeting/Code/MeetingTemplate.xml
+++ b/ui/src/main/resources/Meeting/Code/MeetingTemplate.xml
@@ -196,19 +196,6 @@
         <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.UsersClass</classType>
       </leader>
-      <meetingTitle>
-        <customDisplay/>
-        <disabled>0</disabled>
-        <name>meetingTitle</name>
-        <number>1</number>
-        <picker>0</picker>
-        <prettyName>Title</prettyName>
-        <size>30</size>
-        <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </meetingTitle>
       <notes>
         <customDisplay/>
         <disabled>0</disabled>
@@ -324,9 +311,6 @@
     </property>
     <property>
       <lastEmailSent/>
-    </property>
-    <property>
-      <meetingTitle/>
     </property>
     <property>
       <notes/>

--- a/ui/src/main/resources/Meeting/Code/Migrations/1.9.1.xml
+++ b/ui/src/main/resources/Meeting/Code/Migrations/1.9.1.xml
@@ -20,9 +20,9 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.2" reference="Meeting.Code.Migrations.2\.0" locale="">
+<xwikidoc version="1.2" reference="Meeting.Code.Migrations.1\.9\.1" locale="">
   <web>Meeting.Code.Migrations</web>
-  <name>2.0</name>
+  <name>1.9.1</name>
   <language/>
   <defaultLanguage>en</defaultLanguage>
   <translation>0</translation>
@@ -34,7 +34,7 @@
   <date>1545214225000</date>
   <contentUpdateDate>1545214225000</contentUpdateDate>
   <version>1.1</version>
-  <title>2.0</title>
+  <title>1.9.1</title>
   <comment/>
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>

--- a/ui/src/main/resources/Meeting/Code/Migrations/1.9.5.xml
+++ b/ui/src/main/resources/Meeting/Code/Migrations/1.9.5.xml
@@ -69,7 +69,7 @@
       $needsMigration
       #if ("$!request.confirm" == 'true')
         ## Update the title if it wasn't changed.
-        #if($!meetingTitle != '' &amp;&amp; $!meetingTitle != $mDoc.title)
+        #if("$!meetingTitle" != '' &amp;&amp; $!meetingTitle != $mDoc.title)
           #set ($discard = $mDoc.setTitle($!meetingTitle))
           #set($discard = $mDoc.save("Updated title"))
         #end
@@ -77,13 +77,16 @@
         #set($documentToClean = $xwiki.getXWiki().getDocument($mDocRef, $xcontext.context))
         #set($deprecatedBaseObject = $documentToClean.getObject($meetingClass))
         #set($needsSave = false)
+        #set($toBeDeleted = ['meetingTitle'])
         #foreach ($baseProp in $deprecatedBaseObject.getXClass($xcontext.context).getDeprecatedObjectProperties($deprecatedBaseObject))
-          #set($discard = $deprecatedBaseObject.removeField($baseProp.name))
-          #set($needsSave = true)
+          #if($toBeDeleted.contains($baseProp.name))
+            #set($discard = $deprecatedBaseObject.removeField($baseProp.name))
+            #set($needsSave = true)
+          #end
         #end
         #if ($needsSave)
           #set($discard = $documentToClean.setAuthorReference($xcontext.context.getUserReference()))
-          #set($discard = $xwiki.getXWiki().saveDocument($documentToClean, $msg.get("core.model.xobject.synchronizeObjects.versionSummary"),true, $xcontext.context))
+          #set($discard = $xwiki.getXWiki().saveDocument($documentToClean, 'Migration complete', true, $xcontext.context))
         #end
       #end
     #end

--- a/ui/src/main/resources/Meeting/Code/Migrations/1.9.5.xml
+++ b/ui/src/main/resources/Meeting/Code/Migrations/1.9.5.xml
@@ -56,37 +56,37 @@
     $services.localization.render('meeting.migrations.titleProp')|=
     $services.localization.render('meeting.migrations.hasDeprecatedProp')
     #foreach($md in $allMeetings)
-      #set($mDocRef = $services.model.resolveDocument($md, $services.model.createWikiReference($w)))
-      #set($mDoc = $xwiki.getDocument($mDocRef))
-      #set($meetingObj = $mDoc.getObject($meetingClass))
+      #set($meetingDocRef = $services.model.resolveDocument($md, $services.model.createWikiReference($w)))
+      #set($meetingDoc = $xwiki.getDocument($meetingDocRef))
+      #set($meetingObj = $meetingDoc.getObject($meetingClass))
       #set($meetingTitle = $meetingObj.getValue('meetingTitle'))
       #set($needsMigration = false)
-      #if($!meetingTitle)
+      #if("$!meetingTitle" != '')
         #set($needsMigration = true)
       #end
-      | [[$mDoc.prefixedFullName]] |
+      | [[$meetingDoc.prefixedFullName]] |
       $!meetingTitle |
       $needsMigration
       #if ("$!request.confirm" == 'true')
         ## Update the title if it wasn't changed.
-        #if("$!meetingTitle" != '' &amp;&amp; $!meetingTitle != $mDoc.title)
-          #set ($discard = $mDoc.setTitle($!meetingTitle))
-          #set($discard = $mDoc.save("Updated title"))
+        #if("$!meetingTitle" != '' &amp;&amp; $meetingTitle != $meetingDoc.title)
+          #set ($discard = $meetingDoc.setTitle($meetingTitle))
+          #set($discard = $meetingDoc.save("Updated title"))
         #end
         ## Clean deprecated meetingTitle property.
-        #set($documentToClean = $xwiki.getXWiki().getDocument($mDocRef, $xcontext.context))
-        #set($deprecatedBaseObject = $documentToClean.getObject($meetingClass))
+        #set($meetingXWikiDoc = $xwiki.getXWiki().getDocument($meetingDocRef, $xcontext.context))
+        #set($obj = $meetingXWikiDoc.getObject($meetingClass))
         #set($needsSave = false)
         #set($toBeDeleted = ['meetingTitle'])
-        #foreach ($baseProp in $deprecatedBaseObject.getXClass($xcontext.context).getDeprecatedObjectProperties($deprecatedBaseObject))
+        #foreach ($baseProp in $obj.getXClass($xcontext.context).getDeprecatedObjectProperties($obj))
           #if($toBeDeleted.contains($baseProp.name))
-            #set($discard = $deprecatedBaseObject.removeField($baseProp.name))
+            #set($discard = $obj.removeField($baseProp.name))
             #set($needsSave = true)
           #end
         #end
         #if ($needsSave)
-          #set($discard = $documentToClean.setAuthorReference($xcontext.context.getUserReference()))
-          #set($discard = $xwiki.getXWiki().saveDocument($documentToClean, 'Migration complete', true, $xcontext.context))
+          #set($discard = $meetingXWikiDoc.setAuthorReference($xcontext.context.getUserReference()))
+          #set($discard = $xwiki.getXWiki().saveDocument($meetingXWikiDoc, 'Migration complete', true, $xcontext.context))
         #end
       #end
     #end

--- a/ui/src/main/resources/Meeting/Code/Migrations/1.9.5.xml
+++ b/ui/src/main/resources/Meeting/Code/Migrations/1.9.5.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<xwikidoc version="1.2" reference="Meeting.Code.Migrations.1\.9\.5" locale="">
+  <web>Meeting.Code.Migrations</web>
+  <name>1.9.5</name>
+  <language/>
+  <defaultLanguage>en</defaultLanguage>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <creationDate>1556029586000</creationDate>
+  <parent>Meeting.Code.WebHome</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <date>1556029598000</date>
+  <contentUpdateDate>1556029598000</contentUpdateDate>
+  <version>1.1</version>
+  <title>1.9.5</title>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>false</hidden>
+  <content>{{velocity}}
+#macro(handleWiki $w $meetingClass)
+  #set($meetingClassDoc = $xwiki.getDocument("${w}:${meetingClass}"))
+  #set ($wikiPrettyName = $services.wiki.getById($w).prettyName)
+  #if ("$!wikiPrettyName.trim()" == '')
+    #set ($wikiPrettyName = $w)
+  #end
+  #if ($meetingClassDoc)
+    #set($allMeetings = $services.query.xwql("from doc.object(${meetingClass}) as meeting order by doc.fullName asc").setWiki($w).addFilter('unique').execute())
+    $services.localization.render('meeting.migrations.wiki') $wikiPrettyName
+
+    (((
+    |=
+    $services.localization.render('meeting.migrations.document')|=
+    $services.localization.render('meeting.migrations.titleProp')|=
+    $services.localization.render('meeting.migrations.hasDeprecatedProp')
+    #foreach($md in $allMeetings)
+      #set($mDocRef = $services.model.resolveDocument($md, $services.model.createWikiReference($w)))
+      #set($mDoc = $xwiki.getDocument($mDocRef))
+      #set($meetingObj = $mDoc.getObject($meetingClass))
+      #set($meetingTitle = $meetingObj.getValue('meetingTitle'))
+      #set($needsMigration = false)
+      #if($!meetingTitle)
+        #set($needsMigration = true)
+      #end
+      | [[$mDoc.prefixedFullName]] |
+      $!meetingTitle |
+      $needsMigration
+      #if ("$!request.confirm" == 'true')
+        ## Update the title if it wasn't changed.
+        #if($!meetingTitle != '' &amp;&amp; $!meetingTitle != $mDoc.title)
+          #set ($discard = $mDoc.setTitle($!meetingTitle))
+          #set($discard = $mDoc.save("Updated title"))
+        #end
+        ## Clean deprecated meetingTitle property.
+        #set($documentToClean = $xwiki.getXWiki().getDocument($mDocRef, $xcontext.context))
+        #set($deprecatedBaseObject = $documentToClean.getObject($meetingClass))
+        #set($needsSave = false)
+        #foreach ($baseProp in $deprecatedBaseObject.getXClass($xcontext.context).getDeprecatedObjectProperties($deprecatedBaseObject))
+          #set($discard = $deprecatedBaseObject.removeField($baseProp.name))
+          #set($needsSave = true)
+        #end
+        #if ($needsSave)
+          #set($discard = $documentToClean.setAuthorReference($xcontext.context.getUserReference()))
+          #set($discard = $xwiki.getXWiki().saveDocument($documentToClean, $msg.get("core.model.xobject.synchronizeObjects.versionSummary"),true, $xcontext.context))
+        #end
+      #end
+    #end
+    )))
+
+  #end
+#end
+{{/velocity}}
+
+{{velocity}}
+#if ("$!request.confirm" != 'true')
+  {{html}}
+    &lt;a href="$doc.getURL('view', 'confirm=true')" class='button'&gt;
+      $services.localization.render('meeting.migrations.button')
+    &lt;/a&gt;
+  {{/html}}
+#end
+
+#set($meetingClass = "Meeting.Code.MeetingClass")
+#set($wiki = "$!request.wiki")
+#if ($wiki != '')
+  #handleWiki($wiki, $meetingClass)
+#else
+  #foreach($w in $services.wiki.getAllIds())
+    #handleWiki($w, $meetingClass)
+  #end
+#end
+{{/velocity}}</content>
+</xwikidoc>

--- a/ui/src/main/resources/Meeting/Code/Migrations/MigrationMacros.xml
+++ b/ui/src/main/resources/Meeting/Code/Migrations/MigrationMacros.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<xwikidoc version="1.2" reference="Meeting.Code.Migrations.MigrationMacros" locale="">
+  <web>Meeting.Code.Migrations</web>
+  <name>MigrationMacros</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <creationDate>1556173254000</creationDate>
+  <parent>Meeting.WebHome</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <date>1556174841000</date>
+  <contentUpdateDate>1556174803000</contentUpdateDate>
+  <version>1.1</version>
+  <title>MigrationMacros</title>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>false</hidden>
+  <content>{{velocity}}
+#macro (testMigrationNeeded)
+  #set($query = "from doc.object(Meeting.Code.MeetingClass) as meeting")
+  #set($meetings = $services.query.xwql($query).execute())
+  #set($migrationNeeded = false)
+  #set($migration191 = false)
+  #set($migration195 = false)
+  #foreach($meet in $meetings)
+    #set($meetDoc = $xwiki.getDocument($meet))
+    #set($meetObj = $meetDoc.getObject('Meeting.Code.MeetingClass'))
+    #set($durationString = $meetObj.getValue('durationString'))
+    #set($meetingTitle = $meetObj.getValue('meetingTitle'))
+    ## Check which migration should be executed.
+    #if ($durationString)
+      #set($migrationNeeded = true)
+      #set($migration191 = true)
+    #end
+    #if ($!meetingTitle)
+      #set($migrationNeeded = true)
+      #set($migration195 = true)
+    #end
+  #end
+  #if($migrationNeeded)
+    {{error}}
+      $services.localization.render('meeting.home.migrations')
+      #if(!$hasProgramming)
+        $services.localization.render('meeting.migrations.programming',
+        'https://www.xwiki.org/xwiki/bin/view/Documentation/AdminGuide/Access%20Rights/Permission%20types/#HProgrammingRight')
+      #else
+        #if($migration191)
+          [[Meeting.Code.Migrations.1\.9\.1]]
+        #end
+        #if($migration195)
+          [[Meeting.Code.Migrations.1\.9\.5]]
+        #end
+      #end
+    {{/error}}
+  #end
+#end
+#if($xwiki.rightsmanager.getAllGroupsNamesForMember($xcontext.user).contains('XWiki.XWikiAdminGroup'))
+  #testMigrationNeeded()
+#end
+{{/velocity}}</content>
+</xwikidoc>

--- a/ui/src/main/resources/Meeting/Code/Migrations/MigrationMacros.xml
+++ b/ui/src/main/resources/Meeting/Code/Migrations/MigrationMacros.xml
@@ -47,16 +47,16 @@
   #set($migration191 = false)
   #set($migration195 = false)
   #foreach($meet in $meetings)
-    #set($meetDoc = $xwiki.getDocument($meet))
-    #set($meetObj = $meetDoc.getObject('Meeting.Code.MeetingClass'))
-    #set($durationString = $meetObj.getValue('durationString'))
-    #set($meetingTitle = $meetObj.getValue('meetingTitle'))
+    #set($meetingDoc = $xwiki.getDocument($meet))
+    #set($meetingObj = $meetingDoc.getObject('Meeting.Code.MeetingClass'))
+    #set($durationString = $meetingObj.getValue('durationString'))
+    #set($meetingTitle = $meetingObj.getValue('meetingTitle'))
     ## Check which migration should be executed.
-    #if ($durationString)
+    #if ("$!durationString" != '')
       #set($migrationNeeded = true)
       #set($migration191 = true)
     #end
-    #if ($!meetingTitle)
+    #if ("$!meetingTitle" != '')
       #set($migrationNeeded = true)
       #set($migration195 = true)
     #end
@@ -78,7 +78,7 @@
     {{/error}}
   #end
 #end
-#if($xwiki.rightsmanager.getAllGroupsNamesForMember($xcontext.user).contains('XWiki.XWikiAdminGroup'))
+#if($hasAdmin)
   #testMigrationNeeded()
 #end
 {{/velocity}}</content>

--- a/ui/src/main/resources/Meeting/Code/Translations.xml
+++ b/ui/src/main/resources/Meeting/Code/Translations.xml
@@ -57,6 +57,8 @@ meeting.migrations.number=Number of documents to be modified:
 meeting.migrations.properties=Properties to be updated after executing
 meeting.migrations.startDate=Start Date
 meeting.migrations.status=Status
+meeting.migrations.titleProp=Title property value
+meeting.migrations.hasDeprecatedProp=Needs migration
 meeting.migrations.wiki=Wiki:
 
 meeting.livetable.doc.title=Meeting

--- a/ui/src/main/resources/Meeting/Code/Translations.xml
+++ b/ui/src/main/resources/Meeting/Code/Translations.xml
@@ -47,18 +47,19 @@ contrib.meeting.calendarView=Calendar View
 contrib.meeting.calendarView.title=Calendar View
 contrib.meeting.calendarView.noMacro.admin=To display the calendar view of the meetings, you need to install the Full Calendar Macro on this wiki :
 contrib.meeting.calendarView.noMacro.noAdmin=We are missing the macro displaying the calendar view. Ask this wiki administrator to install the "FullCalendar" Macro.
-meeting.home.migrations=Some properties have been changed since your last upgrade. Please follow the next link to complete the migration:
+meeting.home.migrations=Some properties have been changed since your last upgrade. Please follow the next link/s to complete the migration:
 
 meeting.migrations.button=Execute the modification
 meeting.migrations.deprecatedProps=No deprecated properties
 meeting.migrations.document=Document
 meeting.migrations.endDate=End Date
+meeting.migrations.hasDeprecatedProp=Needs migration
 meeting.migrations.number=Number of documents to be modified:
+meeting.migrations.programming=You need programming rights for executing the migration. More informations [[here&gt;&gt;{0}]]:
 meeting.migrations.properties=Properties to be updated after executing
 meeting.migrations.startDate=Start Date
 meeting.migrations.status=Status
 meeting.migrations.titleProp=Title property value
-meeting.migrations.hasDeprecatedProp=Needs migration
 meeting.migrations.wiki=Wiki:
 
 meeting.livetable.doc.title=Meeting

--- a/ui/src/main/resources/Meeting/Code/WebHomeSheet.xml
+++ b/ui/src/main/resources/Meeting/Code/WebHomeSheet.xml
@@ -39,8 +39,7 @@
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
-  <content>{{include reference="Meeting.Code.Macros"/}}
-{{include reference="Meeting.Code.Migrations.MigrationMacros"/}}
+  <content>{{include reference="Meeting.Code.Migrations.MigrationMacros"/}}
 
 {{velocity}}
 #set($docextras = [])

--- a/ui/src/main/resources/Meeting/Code/WebHomeSheet.xml
+++ b/ui/src/main/resources/Meeting/Code/WebHomeSheet.xml
@@ -40,10 +40,9 @@
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
   <content>{{include reference="Meeting.Code.Macros"/}}
+{{include reference="Meeting.Code.Migrations.MigrationMacros"/}}
 
 {{velocity}}
-#testMigrationNeeded()
-
 #set($docextras = [])
 #set ($discard = $xwiki.ssfx.use('uicomponents/widgets/userpicker/userPicker.css'))
 #set ($discard = $xwiki.ssfx.use('uicomponents/pagination/pagination.css', 'true'))


### PR DESCRIPTION
* deleted meetingTitle prop since the page already has a title and it can be edited in wiki mode
* added migration page for the deprecated property
* renamed the existing migration page to correspond to the version in witch it was implemented

Before Migration
![migration_page](https://user-images.githubusercontent.com/22794181/56597105-758e4c00-65fa-11e9-8892-26ac6bbd5131.png)

After Migration
![migration_after](https://user-images.githubusercontent.com/22794181/56597103-758e4c00-65fa-11e9-9463-7eb0dc14d63c.png)

Homepage
![migration_warning](https://user-images.githubusercontent.com/22794181/56597106-758e4c00-65fa-11e9-90b8-5734bfee7d08.png)
