### PR TITLE
Change the default sort of the meetings #41

### DIFF
--- a/ui/src/main/resources/Meeting/Code/Translations.xml
+++ b/ui/src/main/resources/Meeting/Code/Translations.xml
@@ -31,8 +31,8 @@
   <parent>Meeting.WebHome</parent>
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <date>1597819604000</date>
-  <contentUpdateDate>1597819604000</contentUpdateDate>
+  <date>1511530491000</date>
+  <contentUpdateDate>1511530491000</contentUpdateDate>
   <version>1.1</version>
   <title>Meetings Translations</title>
   <comment/>

--- a/ui/src/main/resources/Meeting/Code/Translations.xml
+++ b/ui/src/main/resources/Meeting/Code/Translations.xml
@@ -31,8 +31,8 @@
   <parent>Meeting.WebHome</parent>
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <date>1511530491000</date>
-  <contentUpdateDate>1511530491000</contentUpdateDate>
+  <date>1597819604000</date>
+  <contentUpdateDate>1597819604000</contentUpdateDate>
   <version>1.1</version>
   <title>Meetings Translations</title>
   <comment/>
@@ -60,6 +60,8 @@ contrib.meeting.field.startDate=Start Date
 contrib.meeting.field.status=Status
 
 contrib.meeting.home.presentation=Use this application to organise meetings, send invitations and have a {0}calendar{1} overview of all the meetings.
+contrib.meeting.home.initialMessage=Below are displayed the meetings available for a year. Click {0}here{1} to view all meetings.
+contrib.meeting.home.allMeetingsMessage=Below are displayed all the meetings created. Click {0}here{1} to view the meetings available for a year.
 contrib.meeting.home.title=Meetings
 
 # Map Macro

--- a/ui/src/main/resources/Meeting/Code/WebHomeSheet.xml
+++ b/ui/src/main/resources/Meeting/Code/WebHomeSheet.xml
@@ -60,11 +60,11 @@ $services.localization.render('contrib.meeting.home.presentation', ['[[**', '**&
   'className': 'Meeting.Code.MeetingClass',
   'translationPrefix': 'meeting.livetable.',
   'tagCloud': true,
-  'rowCount': 15
+  'rowCount': 15,
+  'selectedColumn': 'startDate'
 })
 #if ($request.getParameter('meeting') == 'all')
   $services.localization.render('contrib.meeting.home.allMeetingsMessage', ['[[', "&gt;&gt;${doc}]]"])
-  #set ($options.selectedColumn = 'startDate')
   #set ($options.defaultOrder = 'desc')
 #else
   $services.localization.render('contrib.meeting.home.initialMessage', ['[[**', "&gt;&gt;||queryString='meeting=all']]"])

--- a/ui/src/main/resources/Meeting/Code/WebHomeSheet.xml
+++ b/ui/src/main/resources/Meeting/Code/WebHomeSheet.xml
@@ -31,8 +31,8 @@
   <parent>Meeting.WebHome</parent>
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <date>1547210090000</date>
-  <contentUpdateDate>1547210090000</contentUpdateDate>
+  <date>1597822233000</date>
+  <contentUpdateDate>1597822233000</contentUpdateDate>
   <version>1.1</version>
   <title/>
   <comment/>
@@ -51,20 +51,39 @@ $services.localization.render('contrib.meeting.home.presentation', ['[[**', '**&
   'leader': {"type":"text","size":10,"html":true},
   'place': {"type":"text","size":10},
   'startDate': {"type":"text","size":10},
+  'endDate': {"type":"hidden"},
   'durationDisplay': {"type":"text","filterable":true,"sortable":false,"html":true},
   'status': {"type":"list","size":10},
   '_actions': {"sortable":false,"filterable":false,"html":true,"actions":["delete", "edit"]}
 })
-#set ($options = {
-  'className': 'Meeting.Code.MeetingClass',
-  'translationPrefix': 'meeting.livetable.',
-  'tagCloud': true,
-  'rowCount': 15,
-  'maxPages': 10,
-  'selectedColumn': 'startDate',
-  'defaultOrder': 'desc'
-})
-#set ($columns = ['doc.title', 'leader', 'place', 'startDate', 'durationDisplay', 'status', '_actions'])
+#set ($currentDate = $xwiki.jodatime.dateTime.millis)
+#set ($endDate = $xwiki.jodatime.dateTime.plusYears(1).millis)
+#set ($parameter= $request.getParameter("meeting"))
+#if($parameter=="all")
+  $services.localization.render('contrib.meeting.home.allMeetingsMessage',['[[', "&gt;&gt;${doc}]]"])
+  #set ($options = {
+    'className': 'Meeting.Code.MeetingClass',
+    'translationPrefix': 'meeting.livetable.',
+    'tagCloud': true,
+    'rowCount': 15,
+    'maxPages': 10,
+    'selectedColumn': 'startDate',
+    'defaultOrder': 'desc'
+  })
+#else
+  $services.localization.render('contrib.meeting.home.initialMessage',['[[**','&gt;&gt;||queryString="meeting=all"]]'])
+  #set ($options = {
+    'className': 'Meeting.Code.MeetingClass',
+    'translationPrefix': 'meeting.livetable.',
+    'tagCloud': true,
+    'rowCount': 15,
+    'maxPages': 10,
+    'selectedColumn': 'startDate',
+    'extraParams':"&amp;endDate=${currentDate}-${endDate}",
+    'defaultOrder': 'asc'
+  })
+#end
+#set ($columns = ['doc.title', 'leader', 'place', 'startDate','endDate', 'durationDisplay', 'status', '_actions'])
 #livetable('meeting' $columns $columnsProperties $options)
 {{/velocity}}</content>
 </xwikidoc>

--- a/ui/src/main/resources/Meeting/Code/WebHomeSheet.xml
+++ b/ui/src/main/resources/Meeting/Code/WebHomeSheet.xml
@@ -47,28 +47,27 @@
 #set ($discard = $xwiki.ssfx.use('uicomponents/pagination/pagination.css', 'true'))
 $services.localization.render('contrib.meeting.home.presentation', ['[[**', '**&gt;&gt;Meeting.CalendarView]]'])
 #set ($columnsProperties = {
-  'doc.title': {"type":"text","size":10,"link":"view"},
-  'leader': {"type":"text","size":10,"html":true},
-  'place': {"type":"text","size":10},
-  'startDate': {"type":"text","size":10},
-  'endDate': {"type":"hidden"},
-  'durationDisplay': {"type":"text","filterable":true,"sortable":false,"html":true},
-  'status': {"type":"list","size":10},
-  '_actions': {"sortable":false,"filterable":false,"html":true,"actions":["delete", "edit"]}
+  'doc.title': {'type': 'text', 'size': 10, 'link': 'view'},
+  'leader': {'type': 'text', 'size': 10, 'html': true},
+  'place': {'type': 'text', 'size': 10},
+  'startDate': {'type': 'text', 'size': 10},
+  'endDate': {'type': 'hidden'},
+  'durationDisplay': {'type': 'text', 'filterable': true, 'sortable': false, 'html': true},
+  'status': {'type': 'list', 'size': 10},
+  '_actions': {'sortable': false, 'filterable': false, 'html': true, 'actions': ['delete', 'edit']}
 })
 #set ($options = {
   'className': 'Meeting.Code.MeetingClass',
   'translationPrefix': 'meeting.livetable.',
   'tagCloud': true,
-  'rowCount': 15,
-  'maxPages': 10
+  'rowCount': 15
 })
 #if ($request.getParameter('meeting') == 'all')
   $services.localization.render('contrib.meeting.home.allMeetingsMessage', ['[[', "&gt;&gt;${doc}]]"])
   #set ($options.selectedColumn = 'startDate')
   #set ($options.defaultOrder = 'desc')
 #else
-  $services.localization.render('contrib.meeting.home.initialMessage', ['[[**', '&gt;&gt;||queryString="meeting=all"]]'])
+  $services.localization.render('contrib.meeting.home.initialMessage', ['[[**', "&gt;&gt;||queryString='meeting=all']]"])
   #set ($currentDate = $xwiki.jodatime.dateTime.millis)
   #set ($endDate = $xwiki.jodatime.dateTime.plusYears(1).millis)
   #set ($options.extraParams = "&amp;endDate=${currentDate}-${endDate}")

--- a/ui/src/main/resources/Meeting/Code/WebHomeSheet.xml
+++ b/ui/src/main/resources/Meeting/Code/WebHomeSheet.xml
@@ -56,32 +56,23 @@ $services.localization.render('contrib.meeting.home.presentation', ['[[**', '**&
   'status': {"type":"list","size":10},
   '_actions': {"sortable":false,"filterable":false,"html":true,"actions":["delete", "edit"]}
 })
-#set ($currentDate = $xwiki.jodatime.dateTime.millis)
-#set ($endDate = $xwiki.jodatime.dateTime.plusYears(1).millis)
-#set ($parameter = $request.getParameter("meeting"))
-#if ($parameter == "all")
+#set ($options = {
+  'className': 'Meeting.Code.MeetingClass',
+  'translationPrefix': 'meeting.livetable.',
+  'tagCloud': true,
+  'rowCount': 15,
+  'maxPages': 10
+})
+#if ($request.getParameter("meeting") == 'all')
   $services.localization.render('contrib.meeting.home.allMeetingsMessage', ['[[', "&gt;&gt;${doc}]]"])
-  #set ($options = {
-    'className': 'Meeting.Code.MeetingClass',
-    'translationPrefix': 'meeting.livetable.',
-    'tagCloud': true,
-    'rowCount': 15,
-    'maxPages': 10,
-    'selectedColumn': 'startDate',
-    'defaultOrder': 'desc'
-  })
+  #set ($options.selectedColumn = 'startDate')
+  #set ($options.defaultOrder = 'desc')
 #else
   $services.localization.render('contrib.meeting.home.initialMessage', ['[[**', '&gt;&gt;||queryString="meeting=all"]]'])
-  #set ($options = {
-    'className': 'Meeting.Code.MeetingClass',
-    'translationPrefix': 'meeting.livetable.',
-    'tagCloud': true,
-    'rowCount': 15,
-    'maxPages': 10,
-    'selectedColumn': 'startDate',
-    'extraParams': "&amp;endDate=${currentDate}-${endDate}",
-    'defaultOrder': 'asc'
-  })
+  #set ($currentDate = $xwiki.jodatime.dateTime.millis)
+  #set ($endDate = $xwiki.jodatime.dateTime.plusYears(1).millis)
+  #set ($options.extraParams = "&amp;endDate=${currentDate}-${endDate}")
+  #set ($options.defaultOrder = 'asc')
 #end
 #set ($columns = ['doc.title', 'leader', 'place', 'startDate', 'endDate', 'durationDisplay', 'status', '_actions'])
 #livetable('meeting' $columns $columnsProperties $options)

--- a/ui/src/main/resources/Meeting/Code/WebHomeSheet.xml
+++ b/ui/src/main/resources/Meeting/Code/WebHomeSheet.xml
@@ -31,8 +31,8 @@
   <parent>Meeting.WebHome</parent>
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <date>1597822233000</date>
-  <contentUpdateDate>1597822233000</contentUpdateDate>
+  <date>1547210090000</date>
+  <contentUpdateDate>1547210090000</contentUpdateDate
   <version>1.1</version>
   <title/>
   <comment/>
@@ -58,9 +58,9 @@ $services.localization.render('contrib.meeting.home.presentation', ['[[**', '**&
 })
 #set ($currentDate = $xwiki.jodatime.dateTime.millis)
 #set ($endDate = $xwiki.jodatime.dateTime.plusYears(1).millis)
-#set ($parameter= $request.getParameter("meeting"))
-#if($parameter=="all")
-  $services.localization.render('contrib.meeting.home.allMeetingsMessage',['[[', "&gt;&gt;${doc}]]"])
+#set ($parameter = $request.getParameter("meeting"))
+#if ($parameter == "all")
+  $services.localization.render('contrib.meeting.home.allMeetingsMessage', ['[[', "&gt;&gt;${doc}]]"])
   #set ($options = {
     'className': 'Meeting.Code.MeetingClass',
     'translationPrefix': 'meeting.livetable.',
@@ -71,7 +71,7 @@ $services.localization.render('contrib.meeting.home.presentation', ['[[**', '**&
     'defaultOrder': 'desc'
   })
 #else
-  $services.localization.render('contrib.meeting.home.initialMessage',['[[**','&gt;&gt;||queryString="meeting=all"]]'])
+  $services.localization.render('contrib.meeting.home.initialMessage', ['[[**', '&gt;&gt;||queryString="meeting=all"]]'])
   #set ($options = {
     'className': 'Meeting.Code.MeetingClass',
     'translationPrefix': 'meeting.livetable.',
@@ -79,11 +79,11 @@ $services.localization.render('contrib.meeting.home.presentation', ['[[**', '**&
     'rowCount': 15,
     'maxPages': 10,
     'selectedColumn': 'startDate',
-    'extraParams':"&amp;endDate=${currentDate}-${endDate}",
+    'extraParams': "&amp;endDate=${currentDate}-${endDate}",
     'defaultOrder': 'asc'
   })
 #end
-#set ($columns = ['doc.title', 'leader', 'place', 'startDate','endDate', 'durationDisplay', 'status', '_actions'])
+#set ($columns = ['doc.title', 'leader', 'place', 'startDate', 'endDate', 'durationDisplay', 'status', '_actions'])
 #livetable('meeting' $columns $columnsProperties $options)
 {{/velocity}}</content>
 </xwikidoc>

--- a/ui/src/main/resources/Meeting/Code/WebHomeSheet.xml
+++ b/ui/src/main/resources/Meeting/Code/WebHomeSheet.xml
@@ -32,7 +32,7 @@
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
   <date>1547210090000</date>
-  <contentUpdateDate>1547210090000</contentUpdateDate
+  <contentUpdateDate>1547210090000</contentUpdateDate>
   <version>1.1</version>
   <title/>
   <comment/>
@@ -63,7 +63,7 @@ $services.localization.render('contrib.meeting.home.presentation', ['[[**', '**&
   'rowCount': 15,
   'maxPages': 10
 })
-#if ($request.getParameter("meeting") == 'all')
+#if ($request.getParameter('meeting') == 'all')
   $services.localization.render('contrib.meeting.home.allMeetingsMessage', ['[[', "&gt;&gt;${doc}]]"])
   #set ($options.selectedColumn = 'startDate')
   #set ($options.defaultOrder = 'desc')


### PR DESCRIPTION
*the meeting on the first page are displayed in asc order, filter by the current date and the current date plus one year.
*also, the user can see all the meetings created.